### PR TITLE
Fix/generation bug

### DIFF
--- a/Model/model.py
+++ b/Model/model.py
@@ -182,20 +182,7 @@ class ModelWrapper(ABC):
                 )
 
         if better_transformer:
-            self.logger.info("Optimizing model with BetterTransformer...")
-            try:
-                model = BetterTransformer.transform(
-                    self.model, keep_original_model=True
-                )
-                model.eval()
-            except ValueError:
-                self.logger.warning(
-                    "BetterTransformer not available, using original model..."
-                )
-                model = self.model
-
-            self.model = model
-            torch.cuda.empty_cache()
+            self.model = torch.compile(self.model)
         if warmup:
             n_warmup = 5
             self.logger.info("Warming up model...")

--- a/Model/model.py
+++ b/Model/model.py
@@ -6,7 +6,6 @@ from typing import Optional, Union
 
 import torch
 from dotenv import load_dotenv
-from optimum.bettertransformer import BetterTransformer
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 from transformers.tokenization_utils import BatchEncoding
 


### PR DESCRIPTION
This PR DOES FIX the generation bug!

**ROOT CAUSE**:
The bug was caused because of 'BetterTransformers' (from optimum library) model's transformation during optimization, possibly because optimizations from this library aren't supported in MADLAD (T5 architecture).

**How to fix it: 1st approach**
In order to not have this bug, we would need to NOT set the argument '--optimize'.

**How to fix it: 2nd approach**
Since we're loosing optimizations, we should simply rely on 'torch.compile'. It does a solid optimization during the compilation process (needs a warmup phase to initialize optimized kernels in GPU) without the need for more abstractions.

So...
**What's new**:
- We're using `torch.compile` and warmup as the optimization instead of `BetterTransformers`.
- New argument `--max-new-tokens` (default to 256) to control maximum token generation. This was introduced because MADLAD sets a default of 20 tokens as the maximum token generation.