### PR TITLE
Adding url to allowed hosts in backend with no www

### DIFF
--- a/Backend/translatorapp_v2/translatorapp/settings.py
+++ b/Backend/translatorapp_v2/translatorapp/settings.py
@@ -91,7 +91,9 @@ backend_domain = urlparse(APP_SETTINGS.backend_url).netloc
 print(f"Backend Domain: {backend_domain}")
 
 ALLOWED_HOSTS = (
-    [backend_domain] if not DEBUG else ["*"]  # Use just the domain part of the URL
+    [backend_domain, backend_domain.strip("www.")]
+    if not DEBUG
+    else ["*"]  # Use just the domain part of the URL
 )
 
 # Configure logging


### PR DESCRIPTION
Adding url to allowed hosts in backend with no www, otherwise getting 400 code error in production: `Invalid HTTP_HOST header: 'traductormapuzungun.cl'. You may need to add 'traductormapuzungun.cl' to ALLOWED_HOSTS.`