### PR TITLE
Fixing API url in deployment

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -74,11 +74,11 @@ jobs:
             echo "NEXT_PUBLIC_API_URL=${BACKEND_URL}" >> .env.production
           else
             if [ "${{ steps.set-variant.outputs.variant }}" = "rap" ]; then
-              echo "BACKEND_URL: ${{ vars.BACKEND_URL_RAP }}"
-              echo "NEXT_PUBLIC_API_URL=${{ vars.BACKEND_URL_RAP }}" >> .env.production
+              echo "BACKEND_URL: ${{ vars.URL_RAP }}"
+              echo "NEXT_PUBLIC_API_URL=${{ vars.URL_RAP }}" >> .env.production
             elif [ "${{ steps.set-variant.outputs.variant }}" = "arn" ]; then
-              echo "BACKEND_URL: ${{ vars.BACKEND_URL_ARN }}"
-              echo "NEXT_PUBLIC_API_URL=${{ vars.BACKEND_URL_ARN }}" >> .env.production
+              echo "BACKEND_URL: ${{ vars.URL_ARN }}"
+              echo "NEXT_PUBLIC_API_URL=${{ vars.URL_ARN }}" >> .env.production
             fi
           fi
       - name: Build Docker Image


### PR DESCRIPTION
There was a bug in frontend deployment action where the default cloud run url was used as api url for requests. This meant that requests were sent directly to service bypassing load balancer and getting 400 bad request error. 