### PR TITLE
Option require user for translation

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -14,6 +14,15 @@ on:
         required: false
         type: boolean
         default: false
+      model_name:
+        description: 'Model name'
+        required: true
+        type: string
+      raw_model_name:
+        description: 'Raw model name'
+        required: true
+        type: string
+        default: 'nllb-200-3.3B'
 jobs:
   build-push-gcp:
     name: Build and Push to GCP
@@ -137,8 +146,8 @@ jobs:
             DB_NAME=${{ steps.set-variant.outputs.variant }}
             INVITATION_GUIDE_URL=${{ env.FRONTEND_URL }}
             INSTANCE_CONNECTION_NAME=${{ env.PROJECT_ID }}:${{ env.REGION }}:${{ env.INSTANCE_NAME }}
-            APP_INFERENCE_MODEL_NAME=${{ vars.INFERENCE_MODEL_NAME }}-${{ steps.set-variant.outputs.variant }}
-            APP_RAW_INFERENCE_MODEL_NAME=${{ vars.RAW_INFERENCE_MODEL_NAME }}
+            APP_INFERENCE_MODEL_NAME=${{ github.event.inputs.model_name }}
+            APP_RAW_INFERENCE_MODEL_NAME=${{ github.event.inputs.raw_model_name }}
             APP_INFERENCE_MODEL_URL=${{ env.INFERENCE_URL }}
             APP_RAW_INFERENCE_MODEL_URL=${{ env.RAW_INFERENCE_URL }}
           region: '${{ env.SERVICE_REGION }}'

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -16,6 +16,11 @@ on:
         options:
           - STAGING
           - PRODUCTION
+      translation_requires_auth:
+        description: 'Translation requires auth'
+        required: false
+        type: boolean
+        default: false
 jobs:
   build-push-gcp:
     name: Build and Push to GCP
@@ -131,6 +136,7 @@ jobs:
           env_vars: |-
             SECRET_KEY=${{ env.DJANGO_SECRET_KEY }}
             PRODUCTION=True
+            TRANSLATION_REQUIRES_AUTH=${{ github.event.inputs.translation_requires_auth }}
             VARIANT=${{ steps.set-variant.outputs.variant }}
             DB_HOST=${{ env.DB_HOST }}
             APP_FRONTEND_URL=${{ env.FRONTEND_URL }}

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -9,13 +9,6 @@ on:
         options:
           - rap
           - arn
-      environment:
-        description: 'Environment for deployment'
-        required: true
-        type: choice
-        options:
-          - STAGING
-          - PRODUCTION
       translation_requires_auth:
         description: 'Translation requires auth'
         required: false
@@ -25,7 +18,7 @@ jobs:
   build-push-gcp:
     name: Build and Push to GCP
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.ref == 'refs/heads/main' && 'PRODUCTION' || 'STAGING' }}
     env:
         PROJECT_ID: ${{ secrets.PROJECT_ID }}
         SERVICE_REGION: ${{ vars.SERVICE_REGION }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -16,6 +16,11 @@ on:
         options:
           - PRODUCTION
           - STAGING
+      requires_auth:
+        description: 'Translation requires authentication'
+        required: true
+        type: boolean
+        default: false
 jobs:
   build-push-gcp:
     name: Build and Push to GCP
@@ -65,6 +70,14 @@ jobs:
         run: |-
           echo "NEXT_PUBLIC_VARIANT=${{ steps.set-variant.outputs.variant }}" >> .env.production
           echo "NEXT_PUBLIC_GA_MEASUREMENT_ID=${{ steps.set-ga-id.outputs.ga_id }}" >> .env.production
+
+          # Set translation restriction based on environment
+          if [ "${{ github.event.inputs.requires_auth }}" ]; then
+            echo "NEXT_PUBLIC_TRANSLATION_REQUIRES_AUTH=true" >> .env.production
+          else
+            echo "NEXT_PUBLIC_TRANSLATION_REQUIRES_AUTH=false" >> .env.production
+          fi
+
           # if not production, set the api url to the backend url so we dont use relative path
           if [ "${{ github.event.inputs.environment }}" != "PRODUCTION" ]; then
             SERVICE_NAME_BACKEND=${{ vars.SERVICE_NAME_BACKEND }}-${{ steps.set-variant.outputs.variant }}

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -9,13 +9,6 @@ on:
         options:
           - rap
           - arn
-      environment:
-        description: 'Environment to deploy to'
-        required: true
-        type: choice
-        options:
-          - PRODUCTION
-          - STAGING
       requires_auth:
         description: 'Translation requires authentication'
         required: true
@@ -25,7 +18,7 @@ jobs:
   build-push-gcp:
     name: Build and Push to GCP
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ github.ref == 'refs/heads/main' && 'PRODUCTION' || 'STAGING' }}
 
     env:
         PROJECT_ID: ${{ secrets.PROJECT_ID }}

--- a/Backend/translatorapp_v2/main/management/commands/createUser.py
+++ b/Backend/translatorapp_v2/main/management/commands/createUser.py
@@ -35,7 +35,7 @@ def create_user(username, password, first_name, last_name, role, is_active=True)
             profile.date_of_birth = datetime.now() - timedelta(days=365 * 20)
             profile.organization = "Cenia"
             profile.save()
-        except:
+        except Profile.DoesNotExist:
             Profile.objects.create(
                 user=user,
                 role=role,

--- a/Backend/translatorapp_v2/main/management/commands/createUser.py
+++ b/Backend/translatorapp_v2/main/management/commands/createUser.py
@@ -20,29 +20,56 @@ from main.models import Profile, User
 
 
 def create_user(username, password, first_name, last_name, role, is_active=True):
-    user = User.objects.create_user(
-        username=username,
-        email=username,
-        first_name=first_name,
-        last_name=last_name,
-        password=password,
-        is_active=is_active,
-    )
-    Profile.objects.create(
-        user=user,
-        role=role,
-        date_of_birth=datetime.now() - timedelta(days=365 * 20),
-        organization="Cenia",
-    )
+    # Check if user already exists
+    if User.objects.filter(username=username).exists():
+        print(f"User {username} already exists")
+        user = User.objects.get(username=username)
+        user.first_name = first_name
+        user.last_name = last_name
+        user.is_active = is_active
+        if password:
+            user.set_password(password)
+        try:
+            profile = user.profile
+            profile.role = role
+            profile.date_of_birth = datetime.now() - timedelta(days=365 * 20)
+            profile.organization = "Cenia"
+            profile.save()
+        except:
+            Profile.objects.create(
+                user=user,
+                role=role,
+                date_of_birth=datetime.now() - timedelta(days=365 * 20),
+                organization="Cenia",
+            )
+        user.save()
+        return user
+    else:
+        user = User.objects.create_user(
+            username=username,
+            email=username,
+            first_name=first_name,
+            last_name=last_name,
+            is_active=is_active,
+        )
+        if password:
+            user.set_password(password)
+            user.save()
+        Profile.objects.create(
+            user=user,
+            role=role,
+            date_of_birth=datetime.now() - timedelta(days=365 * 20),
+            organization="Cenia",
+        )
     return user
 
 
 class Command(BaseCommand):
-    help = "Creates a user "
+    help = "Creates a user with admin role and associated profile"
 
     def add_arguments(self, parser):
         parser.add_argument("username", type=str)
-        parser.add_argument("password", type=str)
+        parser.add_argument("password", type=str, default=None)
         parser.add_argument("first_name", type=str)
         parser.add_argument("last_name", type=str)
 

--- a/Backend/translatorapp_v2/main/roles.py
+++ b/Backend/translatorapp_v2/main/roles.py
@@ -12,9 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from django.conf import settings
 from main.models import Profile
 from rest_framework import permissions
-from django.conf import settings
+
 
 class VerifyRolePermission(permissions.BasePermission):
 
@@ -36,16 +37,21 @@ class IsAdmin(VerifyRolePermission):
 
     def __init__(self):
         super().__init__(role=Profile.ADMIN)
-        
+
+
 class TranslationRequiresAuth(permissions.BasePermission):
     """
-    Dynamic permission that requires authentication only if TRANSLATION_REQUIRES_AUTH is True.
-    If TRANSLATION_REQUIRES_AUTH is False, allows all users.
+    Dynamic permission that requires authentication only if
+    TRANSLATION_REQUIRES_AUTH is True. If TRANSLATION_REQUIRES_AUTH
+    is False, allows all users.
     """
+
     def has_permission(self, request, view):
-        translation_requires_auth = getattr(settings, 'TRANSLATION_REQUIRES_AUTH', False)
-        
+        translation_requires_auth = getattr(
+            settings, "TRANSLATION_REQUIRES_AUTH", False
+        )
+
         if not translation_requires_auth:
-           return True
-        
+            return True
+
         return request.user and request.user.is_authenticated

--- a/Backend/translatorapp_v2/main/roles.py
+++ b/Backend/translatorapp_v2/main/roles.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 from main.models import Profile
 from rest_framework import permissions
-
+from django.conf import settings
 
 class VerifyRolePermission(permissions.BasePermission):
 
@@ -36,3 +36,16 @@ class IsAdmin(VerifyRolePermission):
 
     def __init__(self):
         super().__init__(role=Profile.ADMIN)
+        
+class TranslationRequiresAuth(permissions.BasePermission):
+    """
+    Dynamic permission that requires authentication only if TRANSLATION_REQUIRES_AUTH is True.
+    If TRANSLATION_REQUIRES_AUTH is False, allows all users.
+    """
+    def has_permission(self, request, view):
+        translation_requires_auth = getattr(settings, 'TRANSLATION_REQUIRES_AUTH', False)
+        
+        if not translation_requires_auth:
+           return True
+        
+        return request.user and request.user.is_authenticated

--- a/Backend/translatorapp_v2/main/views.py
+++ b/Backend/translatorapp_v2/main/views.py
@@ -34,7 +34,7 @@ from .models import (
     RequestAccess,
     TranslationPair,
 )
-from .roles import IsAdmin, IsNativeAdmin, TranslationRequiresAuth  
+from .roles import IsAdmin, IsNativeAdmin, TranslationRequiresAuth
 from .serializers import (
     FullUserSerializer,
     InvitationSerializer,

--- a/Backend/translatorapp_v2/main/views.py
+++ b/Backend/translatorapp_v2/main/views.py
@@ -34,7 +34,7 @@ from .models import (
     RequestAccess,
     TranslationPair,
 )
-from .roles import IsAdmin, IsNativeAdmin
+from .roles import IsAdmin, IsNativeAdmin, TranslationRequiresAuth  
 from .serializers import (
     FullUserSerializer,
     InvitationSerializer,
@@ -538,7 +538,7 @@ class RequestViewSet(viewsets.ModelViewSet):
 
 class TranslateViewSet(mixins.CreateModelMixin, viewsets.GenericViewSet):
     # since we only want to implement create endpoint we inherit create mixin
-    permission_classes = [AllowAny]  # any user can translate
+    permission_classes = [TranslationRequiresAuth]  # any user can translate
     serializer_class = TranslationPairSerializer
 
     def get_queryset(self, src_lang=None, dst_lang=None, src_text=None):

--- a/Backend/translatorapp_v2/translatorapp/settings.py
+++ b/Backend/translatorapp_v2/translatorapp/settings.py
@@ -275,4 +275,6 @@ SUPPORT_EMAIL = os.environ.get("SUPPORT_EMAIL")
 VARIANT = os.environ.get("VARIANT")
 
 # Convert string environment variable to boolean
-TRANSLATION_REQUIRES_AUTH = os.environ.get("TRANSLATION_REQUIRES_AUTH", "false").lower() == "true"
+TRANSLATION_REQUIRES_AUTH = (
+    os.environ.get("TRANSLATION_REQUIRES_AUTH", "false").lower() == "true"
+)

--- a/Backend/translatorapp_v2/translatorapp/settings.py
+++ b/Backend/translatorapp_v2/translatorapp/settings.py
@@ -273,3 +273,6 @@ EMAIL_USE_SSL = False
 INVITATION_GUIDE_URL = os.environ.get("INVITATION_GUIDE_URL")
 SUPPORT_EMAIL = os.environ.get("SUPPORT_EMAIL")
 VARIANT = os.environ.get("VARIANT")
+
+# Convert string environment variable to boolean
+TRANSLATION_REQUIRES_AUTH = os.environ.get("TRANSLATION_REQUIRES_AUTH", "false").lower() == "true"

--- a/Frontend/translator/src/app/constants.js
+++ b/Frontend/translator/src/app/constants.js
@@ -35,6 +35,14 @@ export const VARIANT_LANG = process.env.NEXT_PUBLIC_VARIANT;
 export const LANG_TITLE = VARIANT_LANG === 'rap' ? 'Rapa Nui' : 'Mapuzungun';
 export const PUBLIC_PATHS = ['/login', '/reset-password', '/reset-password-request', '/request-access', '/invitation' , '/about', '/translator'];
 
+// Translation restriction configuration
+export const TRANSLATION_REQUIRES_AUTH = process.env.NEXT_PUBLIC_TRANSLATION_REQUIRES_AUTH === 'true';
+
+// Helper function to check if translation is restricted for current user
+export const isTranslationRestricted = (currentUser) => {
+  return TRANSLATION_REQUIRES_AUTH && !currentUser;
+};
+
 export const ROLES = [
   {name: "Administrador", value: "NativeAdmin"},
   {name: "Equipo técnico", value: "Admin"},

--- a/Frontend/translator/src/app/translator/translator.css
+++ b/Frontend/translator/src/app/translator/translator.css
@@ -136,3 +136,25 @@ limitations under the License. */
   }
 }
 
+.translator-restriction-notice {
+  position: absolute;
+  bottom: 15%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  animation: fadeInScale 0.6s cubic-bezier(0.4, 0, 0.2, 1) 1.8s both;
+}
+
+@media screen and (max-width: 850px) {
+  .translator-restriction-notice {
+    bottom: 20%;
+    width: 90%;
+  }
+  
+  .translator-restriction-notice > div {
+    flex-direction: column;
+    gap: 1rem;
+    text-align: center;
+  }
+}
+

--- a/README.md
+++ b/README.md
@@ -80,7 +80,24 @@ Create a file named `.env` inside `Frontend/translator`. The file should look so
 ```
 NEXT_PUBLIC_API_URL = "http://127.0.0.1:8000"
 NEXT_PUBLIC_VARIANT = "<arn or rap>"
+# Optional: Control translation access
+NEXT_PUBLIC_TRANSLATION_REQUIRES_AUTH = "false"
 ```
+
+### Translation Restriction Feature
+
+The application supports dynamic translation restrictions that can be configured per deployment:
+
+- **Public Access**: Set `NEXT_PUBLIC_TRANSLATION_REQUIRES_AUTH = "false"` to allow all users to translate. The default for backend is public so no extra steps needed. 
+- **Restricted Access**: 
+  - Frontend: Set `NEXT_PUBLIC_TRANSLATION_REQUIRES_AUTH = "true"` to require user authentication
+  - Backend: Set `TRANSLATION_REQUIRES_AUTH = "True"` to require user authentication.
+
+When restricted, non-authenticated users will see:
+- Lock icon on translate button
+- Restriction notice with login option
+- Disabled feedback section
+- Toast notifications when attempting to translate
 
 # Run Frontend
 Open the `Frontend/translator` folder and run `npm run dev`

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ NEXT_PUBLIC_TRANSLATION_REQUIRES_AUTH = "false"
 
 The application supports dynamic translation restrictions that can be configured per deployment:
 
-- **Public Access**: Set `NEXT_PUBLIC_TRANSLATION_REQUIRES_AUTH = "false"` to allow all users to translate. The default for backend is public so no extra steps needed. 
-- **Restricted Access**: 
+- **Public Access**: Set `NEXT_PUBLIC_TRANSLATION_REQUIRES_AUTH = "false"` to allow all users to translate. The default for backend is public so no extra steps needed.
+- **Restricted Access**:
   - Frontend: Set `NEXT_PUBLIC_TRANSLATION_REQUIRES_AUTH = "true"` to require user authentication
   - Backend: Set `TRANSLATION_REQUIRES_AUTH = "True"` to require user authentication.
 


### PR DESCRIPTION
This PR does the following:

- Adds capability to dynamically set, using environment variables, the requirement for a user to be logged in to use translation. This because different models will require different settings and that can change in time.
- Updates actions to allow model name input to allow different arquitectures and automatically set environment depending on main (prod) or feature (staging) branch.