### PR TITLE
Nllb fix

### DIFF
--- a/Model/model.py
+++ b/Model/model.py
@@ -273,6 +273,13 @@ class NLLBModelWrapper(ModelWrapper):
         if target_lang is None:
             raise ValueError("`target_lang` is required in NLLB models.")
 
+        # map target safely to nllb token
+        target_lang = (
+            nllb_language_token_map[target_lang]
+            if target_lang in nllb_language_token_map
+            else target_lang
+        )
+
         forced_bos_token_id = self.tokenizer.convert_tokens_to_ids(target_lang)
         prediction = self.model.generate(
             **inputs,

--- a/Model/server.py
+++ b/Model/server.py
@@ -72,6 +72,7 @@ def _infer_function_factory(
         logger.info(f"Loading model at {folder_path}")
         # TO DO: CHECK IF MODEL NAME IN FOLDER PATH
 
+        logger.info(f"Model type: {model_type}")
         model_cls = NLLBModelWrapper if model_type == "nllb" else MadLadWrapper
         model = model_cls(
             folder_path,


### PR DESCRIPTION
Map target language during generation safely a second time after tokenization. Also, prints the model type that's being used.